### PR TITLE
Update to css

### DIFF
--- a/components/admin.vue
+++ b/components/admin.vue
@@ -247,6 +247,7 @@
 		display: flex;
 		flex-direction: column;
 		min-height: 100vh;
+		width: 100%
 	}
 
 	#admin.overlay-open {


### PR DESCRIPTION
@owenallenaz This is a quick css update, not sure if you want it or not. The issue is when the overlay was opened the admin background moved to be the width of about a 1/3rd the screen. Add width 100% to maintain the admin views width with the overlay open. 